### PR TITLE
Add danger-go plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ You can use Danger to codify your teams norms, leaving humans to think about har
 - [danger-vale](https://github.com/MatMoore/danger-vale) - Vale plugin for Danger.
 - [danger-slack](https://github.com/duck8823/danger-slack) - Post a notification to slack in a Dangerfile.
 - [danger-review_requests](https://github.com/m-nakamura145/danger-review_requests) - Danger plugin to request a review in pull requests.
+- [danger-go](https://github.com/KennethanCeyer/danger-go) - A Danger plugin for Golang.
 
 ### TypeScript (danger-js)
 - [danger-plugin-flow](https://github.com/withspectrum/danger-plugin-flow) - Ensure all JS files that get touched in a PR are flow typed.


### PR DESCRIPTION
I've added the [`danger-go`](https://github.com/KennethanCeyer/danger-go)

This plugin will help to get the lint result with danger for Golang users (binder with [golint](https://github.com/golang/lint))

![das](https://user-images.githubusercontent.com/7090315/56239740-c10d9b00-60cc-11e9-93c5-76e8480993df.png)

And also there are plans to adding options

- documentation for `basedir` option
- add `type` option, and this type option supports to choose analysis types (default: golint, other options: govet, gofmt)
