### PR TITLE
Fix dead links

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,12 +111,12 @@ You can use Danger to codify your teams norms, leaving humans to think about har
 - https://github.com/SwifterSwift/SwifterSwift/blob/master/Dangerfile
 - https://github.com/IBAnimatable/IBAnimatable/blob/master/Dangerfile
 - https://github.com/CocoaPods/CocoaPods/blob/master/Dangerfile
-- https://github.com/artsy/eigen/blob/master/Dangerfile
 - https://github.com/artsy/energy/blob/master/Dangerfile
 - https://github.com/SwiftWeekly/swiftweekly.github.io/blob/master/Dangerfile
 - https://github.com/pusher/chatkit-swift/blob/master/Dangerfile
 
 ### TypeScript (danger-js)
+- https://github.com/artsy/eigen/blob/main/dangerfile.ts
 - https://github.com/artsy/emission/blob/master/dangerfile.ts
 - https://github.com/artsy/force/blob/main/dangerfile.ts
 

--- a/README.md
+++ b/README.md
@@ -108,7 +108,6 @@ You can use Danger to codify your teams norms, leaving humans to think about har
 ## Dangerfiles
 
 ### Ruby (danger)
-- https://github.com/Moya/Moya/blob/master/Dangerfile
 - https://github.com/SwifterSwift/SwifterSwift/blob/master/Dangerfile
 - https://github.com/IBAnimatable/IBAnimatable/blob/master/Dangerfile
 - https://github.com/CocoaPods/CocoaPods/blob/master/Dangerfile
@@ -123,6 +122,7 @@ You can use Danger to codify your teams norms, leaving humans to think about har
 
 ### Swift (danger-swift)
 - https://github.com/Moya/Harvey/blob/master/Dangerfile.swift
+- https://github.com/Moya/Moya/blob/master/Dangerfile.swift
 
 # Peril
 

--- a/README.md
+++ b/README.md
@@ -111,7 +111,6 @@ You can use Danger to codify your teams norms, leaving humans to think about har
 - https://github.com/SwifterSwift/SwifterSwift/blob/master/Dangerfile
 - https://github.com/IBAnimatable/IBAnimatable/blob/master/Dangerfile
 - https://github.com/CocoaPods/CocoaPods/blob/master/Dangerfile
-- https://github.com/artsy/force/blob/master/Dangerfile
 - https://github.com/artsy/eigen/blob/master/Dangerfile
 - https://github.com/artsy/energy/blob/master/Dangerfile
 - https://github.com/SwiftWeekly/swiftweekly.github.io/blob/master/Dangerfile
@@ -119,6 +118,7 @@ You can use Danger to codify your teams norms, leaving humans to think about har
 
 ### TypeScript (danger-js)
 - https://github.com/artsy/emission/blob/master/dangerfile.ts
+- https://github.com/artsy/force/blob/main/dangerfile.ts
 
 ### Swift (danger-swift)
 - https://github.com/Moya/Harvey/blob/master/Dangerfile.swift

--- a/README.md
+++ b/README.md
@@ -141,7 +141,6 @@ Peril provides no implicit actions like that, it instead offers a JavaScript run
 - https://github.com/CocoaPods/peril-settings
 - https://github.com/Moya/moya-peril
 - https://github.com/RxSwiftCommunity/peril
-- https://github.com/xcode-project-manager/peril-settings
 - https://github.com/loadsmart/peril-staging-settings
 - https://github.com/wearereasonablepeople/peril-settings
 - https://github.com/wemake-services/kira-review

--- a/README.md
+++ b/README.md
@@ -111,13 +111,13 @@ You can use Danger to codify your teams norms, leaving humans to think about har
 - https://github.com/SwifterSwift/SwifterSwift/blob/master/Dangerfile
 - https://github.com/IBAnimatable/IBAnimatable/blob/master/Dangerfile
 - https://github.com/CocoaPods/CocoaPods/blob/master/Dangerfile
-- https://github.com/artsy/energy/blob/master/Dangerfile
 - https://github.com/SwiftWeekly/swiftweekly.github.io/blob/master/Dangerfile
 - https://github.com/pusher/chatkit-swift/blob/master/Dangerfile
 
 ### TypeScript (danger-js)
 - https://github.com/artsy/eigen/blob/main/dangerfile.ts
 - https://github.com/artsy/emission/blob/master/dangerfile.ts
+- https://github.com/artsy/energy/blob/main/dangerfile.ts
 - https://github.com/artsy/force/blob/main/dangerfile.ts
 
 ### Swift (danger-swift)

--- a/README.md
+++ b/README.md
@@ -121,7 +121,6 @@ You can use Danger to codify your teams norms, leaving humans to think about har
 - https://github.com/artsy/force/blob/main/dangerfile.ts
 
 ### Swift (danger-swift)
-- https://github.com/Moya/Harvey/blob/master/Dangerfile.swift
 - https://github.com/Moya/Moya/blob/master/Dangerfile.swift
 
 # Peril


### PR DESCRIPTION
Close #30

- Moya/Moya has moved to Danger.swift
- artsy/force has moved to Danger JS
- artsy/eigen has moved to Danger JS
- artsy/energy has moved to Danger JS
- Moya/Harvey repository has gone
- xcode-project-manager organization has gone
